### PR TITLE
Update jekyll-gh-pages.yml

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -28,15 +28,34 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # (Optional) Add Linting Step
+      # Requires installing markdownlint-cli, e.g., via npm
+      # You might need to run `npm install -g markdownlint-cli` or use a dedicated action
+      # Example using a dedicated action (simpler):
+      - name: Lint Markdown # Checks all markdown files in the repo
+        uses: avto-dev/markdown-lint@v1
+        with:
+          # Optional: specify config file, rules, globs, etc.
+          # config: '.markdownlint.yaml'
+          args: '.' # Lint all files from the root
+
       - name: Setup Pages
+        id: pages # Added id to potentially reference outputs later if needed
         uses: actions/configure-pages@v5
+
+      # This action handles Ruby setup, Gem installation (using Gemfile.lock for caching),
+      # and Jekyll build (setting JEKYLL_ENV=production by default).
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
-          destination: ./_site
+          source: ./ # Default source location
+          destination: ./_site # Default build destination
+
       - name: Upload artifact
+        # Automatically uploads the built site from './_site'
         uses: actions/upload-pages-artifact@v3
+        # No need to specify 'path' if using default './_site' destination
 
   # Deployment job
   deploy:
@@ -44,8 +63,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: build # Ensures the build job succeeded
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        # This action automatically downloads the artifact uploaded by
+        # 'upload-pages-artifact' and deploys it.


### PR DESCRIPTION
No Major Structural Change Needed: Your original workflow is already very good and uses current best practices.
Ensure Gemfile.lock: The most crucial step for performance is to have a Gemfile and Gemfile.lock in your repository so actions/jekyll-build-pages can cache dependencies effectively.
Added Linting (Optional but Recommended): The example adds a Markdown linting step (avto-dev/markdown-lint@v1) for quality control. You'll need to configure the linter rules separately in your repository.
Comments and Clarity: Added comments explaining what specific actions do (like internal caching and default JEKYLL_ENV).
IDs: Added an id to the Setup Pages step (id: pages), although not strictly necessary here, it's good practice if you might need to reference its outputs later.